### PR TITLE
[DRAFT] 댓글 ID 중복 수정

### DIFF
--- a/views/skin/user/default/create.blade.php
+++ b/views/skin/user/default/create.blade.php
@@ -29,7 +29,7 @@
             @endif
             @if($config->get('secret') === true && !Auth::guest())
             <div class="comment_form_option">
-                <input type="checkbox" name="display" value="secret" id="private_text"><label for="private_text">{{ xe_trans('comment::secret') }}</label>
+                <input type="checkbox" name="display" value="secret" id="private_text--{{ $targetId }}--{{ $instanceId }}--{{ $targetType }}"><label for="private_text--{{ $targetId }}--{{ $instanceId }}--{{ $targetType }}">{{ xe_trans('comment::secret') }}</label>
             </div>
             @endif
             <div class="comment_form_btn">

--- a/views/skin/user/default/edit.blade.php
+++ b/views/skin/user/default/edit.blade.php
@@ -26,8 +26,8 @@
                 @endif
                 @if($config->get('secret') === true && !Auth::guest())
                     <div class="comment_form_option">
-                        <input type="checkbox" name="display" value="secret" id="private_text" {{ $comment->display === Xpressengine\Plugins\Comment\Models\Comment::DISPLAY_SECRET ? 'checked' : '' }}>
-                        <label for="private_text">{{ xe_trans('comment::secret') }}</label>
+                        <input type="checkbox" name="display" value="secret" id="private_text--{{ $instanceId }}--{{ $comment->id }}" {{ $comment->display === Xpressengine\Plugins\Comment\Models\Comment::DISPLAY_SECRET ? 'checked' : '' }}>
+                        <label for="private_text--{{ $instanceId }}--{{ $comment->id }}">{{ xe_trans('comment::secret') }}</label>
                     </div>
                 @endif
                 <div class="comment_form_btn">

--- a/views/skin/user/default/reply.blade.php
+++ b/views/skin/user/default/reply.blade.php
@@ -33,7 +33,7 @@
                 @if($config->get('secret') === true && !Auth::guest())
                 <div class="comment_form_option">
                     <!-- [D] id, for 값 동일하게 적용 -->
-                    <input type="checkbox" name="display" value="secret" id="private_text_reply"><label for="private_text_reply">{{ xe_trans('comment::secret') }}</label>
+                    <input type="checkbox" name="display" value="secret" id="private_text_reply--{{ $comment->instance_id }}--{{ $comment->target->target_id }}--{{ $comment->id }}--{{ $targetType }}"><label for="private_text_reply--{{ $comment->instance_id }}--{{ $comment->target->target_id }}--{{ $comment->id }}--{{ $targetType }}">{{ xe_trans('comment::secret') }}</label>
                 </div>
                 @endif
                 <div class="comment_form_btn">


### PR DESCRIPTION
일부 ID가 `private_text`, `private_text_reply`로 고정됨 -> ID에 `$targetId` 등 식별자 추가

- [x] ~~한 화면에 **다른** 댓글에 대한 2개 이상의 uio 사용 시 ID 중복 - 해결~~
- [ ] 한 화면에 **같은** 댓글에 대한 2개 이상의 uio 사용 시 ID 중복 - 해결 안 됨